### PR TITLE
Replace Goreleaser changelog generator with PR-based generator

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,0 +1,35 @@
+{
+  "pr_template": "- ${{TITLE}} (PR #${{NUMBER}})",
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": [
+        "enhancement",
+        "feature"
+      ]
+    },
+    {
+      "title": "## 🛠️ Changes",
+      "labels": [
+        "change"
+      ]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": [
+        "bug",
+        "fix"
+      ]
+    },
+    {
+      "title": "## 📄 Documentation",
+      "labels": [
+        "documentation"
+      ]
+    }
+  ],
+  "ignore_labels": [
+    "ignore"
+  ],
+  "template": "${{CHANGELOG}}\n\n<details><summary>Uncategorized</summary><p>\n\n${{UNCATEGORIZED}}\n</p></details>"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,21 @@ jobs:
       run: docker login -u "${{ secrets.QUAY_IO_USERNAME }}" -p "${{ secrets.QUAY_IO_PASSWORD }}" quay.io
     - name: Generate artifacts
       run: make crd
+    - name: Build changelog from PRs with labels
+      id: build_changelog
+      uses: mikepenz/release-changelog-builder-action@v1.2.3
+      with:
+        configuration: ".github/changelog-configuration.json"
+        # Prereleases still get a changelog, but the next full release gets a diff since the last full release,
+        # combining possible changelogs of all previous prereleases inbetween.
+        ignorePreReleases: "true"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Make release notes
+      run: echo "${{steps.build_changelog.outputs.changelog}}" > .github/release-notes.md
     - name: Publish releases
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: release
+        args: release --release-notes .github/release-notes.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ gen### Go template
 
 bin/
 dist/
+.github/release-notes.md
 clustercode-crd*.yaml
 clustercode
 testbin/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,3 @@
-# This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
 
 builds:
@@ -35,20 +34,14 @@ dockers:
   - "docker.io/ccremer/clustercode:v{{ .Version }}"
   - "quay.io/ccremer/clustercode:v{{ .Version }}"
 
-  - "docker.io/ccremer/clustercode:{{ if .Prerelease }}v{{ .Version }}{{ else }}v{{ .Major }}{{ end }}"
-  - "quay.io/ccremer/clustercode:{{ if .Prerelease }}v{{ .Version }}{{ else }}v{{ .Major }}{{ end }}"
+  # For prereleases, updating `latest` and the floating tags of the major
+  # version does not make sense. Only the image for the exact version should
+  # be pushed.
+  - "{{ if .Prerelease }}docker.io/ccremer/clustercode:v{{ .Major }}{{ end }}"
+  - "{{ if .Prerelease }}quay.io/ccremer/clustercode:v{{ .Major }}{{ end }}"
 
-  - "docker.io/ccremer/clustercode:{{ if .Prerelease }}v{{ .Version }}{{ else }}latest{{ end }}"
-  - "quay.io/ccremer/clustercode:{{ if .Prerelease }}v{{ .Version }}{{ else }}latest{{ end }}"
-
-changelog:
-  sort: asc
-  filters:
-    exclude:
-    - '^(D|d)oc(s|umentation):'
-    - '^(T|t)ests?:'
-    - '^(R|r)efactor:'
-    - '^Merge pull request'
+  - "{{ if .Prerelease }}docker.io/ccremer/clustercode:latest{{ end }}"
+  - "{{ if .Prerelease }}quay.io/ccremer/clustercode:latest{{ end }}"
 
 release:
   prerelease: auto


### PR DESCRIPTION
## Summary

Goreleaser builds changelog from commits, which are too detailed and uncategorized for human readers.

The alternative changelog generator uses GitHub API to build a changelog from PRs, categorized by labels.
