### PR TITLE
Fix failing e2e test in PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ lint: fmt vet ## Invokes the fmt and vet targets
 $(BIN_FILENAME):
 	$(build_cmd)
 
-docker-build: $(BIN_FILENAME) $(KIND_KUBECONFIG) ## Build the docker image
+docker-build: $(BIN_FILENAME) ## Build the docker image
 	docker build . -t $(DOCKER_IMG) -t $(QUAY_IMG) -t $(E2E_IMG)
 
 docker-push: ## Push the docker image
@@ -111,7 +111,7 @@ docker-push: ## Push the docker image
 install_bats: ## Installs the bats util via NPM
 	$(MAKE) -C e2e install_bats
 
-e2e_test: install_bats $(SETUP_E2E_TEST) docker-build ## Runs the e2e test suite
+e2e_test: install_bats $(SETUP_E2E_TEST) $(KIND_KUBECONFIG) docker-build ## Runs the e2e test suite
 	docker push $(E2E_IMG)
 	$(MAKE) -C e2e run_bats -e KUBECONFIG=../$(KIND_KUBECONFIG)
 

--- a/e2e/test2.bats
+++ b/e2e/test2.bats
@@ -12,12 +12,12 @@ DEBUG_DETIK="true"
 	reset_debug
 }
 
-@test "verify the clustercode plan" {
+@test "verify the clustercode plan cronjob" {
   go run sigs.k8s.io/kustomize/kustomize/v3 build test2 > debug/test2.yaml
   sed -i "s/\$RANDOM/'$RANDOM'/" debug/test2.yaml
   run kubectl apply -f debug/test2.yaml
   debug "$output"
 
-  try "at most 20 times every 2s to find 1 cronjob named 'test-plan-scan-job' with '.status.active[*].kind' being 'Job'"
+  try "at most 20 times every 5s to find 1 pod named 'test-plan-scan-job' with 'status' being 'Succeeded'"
 
 }


### PR DESCRIPTION
## Summary
verify if there's an active job in a cronjob is unstable, as the status field is being cleared again

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Update tests.
