### PR TITLE
Replace local registry by loading e2e images directly onto KIND cluster

### DIFF
--- a/.github/workflows/Makefile
+++ b/.github/workflows/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test_codeclimate
-test_codeclimate: test ## Run tests for CodeClimate
+test_codeclimate: integration_test ## Run tests for CodeClimate
 	@sed -i "s%github.com/ccremer/%%" cover.out
 
 workflow_master_url := 	https://api.github.com/repos/$(DOCUMENTATION_REPOSITORY)/actions/workflows/build.yml/dispatches

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run e2e tests
-      run: make crd install_bats setup_e2e_test e2e_test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false
+      run: make crd e2e_test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false
     - name: Show e2e debug logs
       run: cat e2e/debug/detik/*
   image:

--- a/Makevariables.mk
+++ b/Makevariables.mk
@@ -1,9 +1,13 @@
-
+VERSION ?= $(shell date +%Y-%m-%d_%H-%M-%S)
 BIN_FILENAME ?= clustercode
 
 DOCS_DIR := docs
 
 IMG_TAG ?= latest
+E2E_TAG ?= e2e_$(VERSION)
+E2E_REPO ?= local.dev/clustercode/e2e
+
+E2E_IMG := $(E2E_REPO):$(E2E_TAG)
 
 CRD_SPEC_VERSION ?= v1
 
@@ -17,8 +21,6 @@ KIND_KUBECONFIG ?= ./testbin/kind-kubeconfig
 KIND_NODE_VERSION ?= v1.19.4
 KIND_CLUSTER ?= clustercode-$(KIND_NODE_VERSION)
 KIND_KUBECTL_ARGS ?= --validate=true
-KIND_REGISTRY_NAME ?= kind-registry
-KIND_REGISTRY_PORT ?= 5000
 
 KUSTOMIZE ?= go run sigs.k8s.io/kustomize/kustomize/v3
 KUSTOMIZE_BUILD_CRD ?= $(KUSTOMIZE) build $(CRD_ROOT_DIR)

--- a/e2e/kind-config.yaml
+++ b/e2e/kind-config.yaml
@@ -1,9 +1,5 @@
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
-containerdConfigPatches:
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
-    endpoint = ["http://kind-registry:5000"]
 nodes:
   - role: control-plane
     extraMounts:

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "clustercode",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "bats": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.2.1.tgz",
+      "integrity": "sha512-2fcPDRQa/Kvh6j1IcCqsHpT5b9ObMzRzw6abC7Bg298PX8Qdh9VRkvO2WJUEhdyfjq2rLBCOAWdcv0tS4+xTUA==",
+      "dev": true
+    }
+  }
+}

--- a/e2e/test1.bats
+++ b/e2e/test1.bats
@@ -14,7 +14,7 @@ DEBUG_DETIK="true"
 
 @test "verify the deployment" {
   go run sigs.k8s.io/kustomize/kustomize/v3 build test1 > debug/test1.yaml
-  run sed -i "s/\$RANDOM/'$RANDOM'/" debug/test1.yaml
+  sed -i -e "s|\$E2E_IMAGE|${E2E_IMAGE}|" debug/test1.yaml
   debug "$output"
   run kubectl apply -f debug/test1.yaml
   debug "$output"

--- a/e2e/test1/deployment.yaml
+++ b/e2e/test1/deployment.yaml
@@ -6,15 +6,12 @@ metadata:
   namespace: system
 spec:
   template:
-    metadata:
-      labels:
-        app.kubernetes.io/version: $RANDOM
     spec:
       containers:
       - name: clustercode
-        image: localhost:5000/clustercode/operator:e2e
-        imagePullPolicy: Always
+        image: $E2E_IMAGE
         args:
         - -v
         - operate
-        - --operator.clustercode-image=localhost:5000/clustercode/operator:e2e
+        - --operator.clustercode-image
+        - $E2E_IMAGE


### PR DESCRIPTION
## Summary

Sometimes there are pull issues when cluster tries to load from docker registry.
This should now also restart the operator when the image is changed.
It also reduces disk usage by not having to store the images in KIND and ALSO on the local registry.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Update tests.
