### PR TITLE
Modularize make structure

### DIFF
--- a/.github/workflows/Makefile
+++ b/.github/workflows/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test_codeclimate
-test_codeclimate: integration_test ## Run tests for CodeClimate reporting
+codeclimate-test: integration-test ## Run tests for CodeClimate reporting
 	@sed -i "s%github.com/ccremer/%%" cover.out
 
 workflow_master_url := 	https://api.github.com/repos/$(DOCUMENTATION_REPOSITORY)/actions/workflows/build.yml/dispatches

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Test & Publish Code Coverage
       uses: paambaati/codeclimate-action@v2.7.5
       with:
-        coverageCommand: make test_codeclimate
+        coverageCommand: make codeclimate-test
         prefix: ${{ github.event.repository.name }}
         coverageLocations:
           "${{github.workspace}}/cover.out:gocov"
@@ -51,7 +51,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Run e2e tests
-      run: make crd e2e_test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false -e bats_args="-F junit"
+      run: make crd e2e-test -e CRD_SPEC_VERSION=${{ matrix.crd-spec-version }} -e KIND_NODE_VERSION=${{ matrix.kind-node-version }} -e KIND_KUBECTL_ARGS=--validate=false -e bats_args="-F junit"
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v1
       if: success() || failure()

--- a/Makefile
+++ b/Makefile
@@ -1,92 +1,175 @@
 # Set Shell to bash, otherwise some targets fail with dash/zsh etc.
 SHELL := /bin/bash
 
-include Makevariables.mk
+# Disable built-in rules
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-builtin-variables
+.SUFFIXES:
+.SECONDARY:
+
+PROJECT_ROOT_DIR = .
+include Makefile.vars.mk
+
 include .github/workflows/Makefile
-include docs/Makefile
-include e2e/Makefile
 
-build_cmd ?= CGO_ENABLED=0 go build -o $(BIN_FILENAME) main.go
+e2e_make := $(MAKE) -C e2e
+docs_make := $(MAKE) -C docs
+media_make := $(MAKE) -C data
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
+go_build ?= CGO_ENABLED=0 go build -o $(BIN_FILENAME) main.go
+
+# Run tests (see https://sdk.operatorframework.io/docs/building-operators/golang/references/envtest-setup)
+ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 
 all: build ## Invokes the build target
 
+.PHONY: test
 test: fmt vet ## Run tests
 	go test ./... -coverprofile cover.out
 
-$(TESTBIN_DIR):
-	mkdir -p $(TESTBIN_DIR)
-
-integration_test: export ENVTEST_K8S_VERSION = $(INTEGRATIONTEST_K8S_VERSION)
-integration_test: generate fmt vet $(TESTBIN_DIR) ## Run integration tests with envtest
+integration-test: export ENVTEST_K8S_VERSION = $(INTEGRATIONTEST_K8S_VERSION)
+integration-test: generate fmt vet $(testbin_created) ## Run integration tests with envtest
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test -tags=integration -v ./... -coverprofile cover.out
 
-build: generate fmt vet ## Build manager binary
-	$(build_cmd)
+.PHONY: build
+build: generate fmt vet $(BIN_FILENAME) ## Build manager binary
 
+.PHONY: run
 run: export BACKUP_ENABLE_LEADER_ELECTION = $(ENABLE_LEADER_ELECTION)
 run: fmt vet ## Run against the configured Kubernetes cluster in ~/.kube/config
-	go run ./main.go
+	go run ./main.go -v operate --operator.clustercode-image=$(E2E_IMG)
 
+.PHONY: install
 install: generate ## Install CRDs into a cluster
-	$(KUSTOMIZE) build $(CRD_ROOT_DIR)/v1 | kubectl apply -f -
+	$(KUSTOMIZE) build $(CRD_ROOT_DIR) | kubectl apply $(KIND_KUBECTL_ARGS) -f -
 
+.PHONY: uninstall
 uninstall: generate ## Uninstall CRDs from a cluster
-	$(KUSTOMIZE) build $(CRD_ROOT_DIR)/v1 | kubectl delete -f -
+	$(KUSTOMIZE) build $(CRD_ROOT_DIR) | kubectl delete -f -
 
+.PHONY: deploy
 deploy: generate ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
+.PHONY: generate
 generate: ## Generate manifests e.g. CRD, RBAC etc.
 	@CRD_ROOT_DIR="$(CRD_ROOT_DIR)" go generate -tags=generate generate.go
 	@rm config/*.yaml
 
+.PHONY: crd
 crd: generate ## Generate CRD to file
-	$(KUSTOMIZE) build $(CRD_ROOT_DIR) > $(CRD_FILE)
+	$(KUSTOMIZE) build $(CRD_ROOT_DIR) -o $(CRD_FILE)
 
+.PHONY: fmt
 fmt: ## Run go fmt against code
 	go fmt ./...
 
+.PHONY: vet
 vet: ## Run go vet against code
 	go vet ./...
 
+.PHONY: lint
 lint: fmt vet ## Invokes the fmt and vet targets
 	@echo 'Check for uncommitted changes ...'
 	git diff --exit-code
 
-blank-media:
-	@mkdir data/source data/intermediate data/target || true
-	docker run --rm -it -u $(shell id -u) -v $(PWD)/data/source:/data $(FFMPEG_IMG) -y -hide_banner -t 30 -f lavfi -i color=c=black:s=320x240 -c:v libx264 -tune stillimage -pix_fmt yuv420p /data/blank_video.mp4
-	@docker run --rm -it -v $(PWD)/data/source:/data --entrypoint /bin/sh $(FFMPEG_IMG) -c "chmod -R 664 /data/*"
-
-clean-media:
-	rm -r data/intermediate data/target || true
-
-# Build the binary without running generators
-.PHONY: $(BIN_FILENAME)
-$(BIN_FILENAME):
-	$(build_cmd)
-
+.PHONY: docker-build
 docker-build: export GOOS = linux
 docker-build: $(BIN_FILENAME) ## Build the docker image
 	docker build . -t $(DOCKER_IMG) -t $(QUAY_IMG) -t $(E2E_IMG)
 
+.PHONY: docker-push
 docker-push: ## Push the docker image
 	docker push $(DOCKER_IMG)
 	docker push $(QUAY_IMG)
 
 clean: export KUBECONFIG = $(KIND_KUBECONFIG)
-clean: clean-media clean-e2e ## Cleans up the generated resources
+clean: e2e-clean kind-clean media-clean docs-clean ## Cleans up the generated resources
 	rm -r testbin/ dist/ bin/ cover.out $(BIN_FILENAME) || true
 
 .PHONY: help
 help: ## Show this help
 	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+###
+### Assets
+###
+
+$(testbin_created):
+	mkdir -p $(TESTBIN_DIR)
+	# a marker file must be created, because the date of the
+	# directory may update when content in it is created/updated,
+	# which would cause a rebuild / re-initialization of dependants
+	@touch $(testbin_created)
+
+# Build the binary without running generators
+.PHONY: $(BIN_FILENAME)
+$(BIN_FILENAME):
+	$(go_build)
+
+###
+### KIND
+###
+
+.PHONY: kind-setup
+kind-setup: ## Creates a kind instance if one does not exist yet.
+	@$(e2e_make) kind-setup
+
+.PHONY: kind-clean
+kind-clean: ## Removes the kind instance if it exists.
+	@$(e2e_make) kind-clean
+
+.PHONY: kind-run
+kind-run: export KUBECONFIG = $(KIND_KUBECONFIG)
+kind-run: kind-setup install run ## Runs the operator on the local host but configured for the kind cluster
+
+kind-e2e-image: docker-build
+	$(e2e_make) kind-e2e-image
+
+###
+### E2E Test
+###
+
+.PHONY: e2e-test
+e2e-test: export KUBECONFIG = $(KIND_KUBECONFIG)
+e2e-test: e2e-setup docker-build install blank-media ## Run the e2e tests
+	@$(e2e_make) test
+
+.PHONY: e2e-setup
+e2e-setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+e2e-setup: ## Run the e2e setup
+	@$(e2e_make) setup
+
+.PHONY: e2e-clean-setup
+e2e-clean-setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+e2e-clean-setup: ## Clean the e2e setup (e.g. to rerun the e2e-setup)
+	@$(e2e_make) clean-setup
+
+.PHONY: e2e-clean
+e2e-clean: ## Remove all e2e-related resources (incl. all e2e Docker images)
+	@$(e2e_make) clean
+
+###
+### Documentation
+###
+
+docs-clean: ## Remove all documentation resources
+	@$(docs_make) clean
+
+docs-preview: ## Preview documentation in local web server and browser
+	@$(docs_make) preview
+
+docs-build: ## Build documentation
+	@$(docs_make) build
+
+###
+### Media
+###
+
+media-clean: ## Remove all media resources
+	@$(media_make) clean
+
+blank-media: ## Preview documentation in local web server and browser
+	@$(media_make) blank-media

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -1,42 +1,38 @@
-VERSION ?= $(shell date +%Y-%m-%d_%H-%M-%S)
-BIN_FILENAME ?= clustercode
-
-DOCS_DIR := docs
-E2E_DIR := e2e
-
 IMG_TAG ?= latest
-E2E_TAG ?= e2e_$(VERSION)
-E2E_REPO ?= local.dev/clustercode/e2e
 
-E2E_IMG := $(E2E_REPO):$(E2E_TAG)
+BIN_FILENAME ?= $(PROJECT_ROOT_DIR)/clustercode
+TESTBIN_DIR ?= $(PROJECT_ROOT_DIR)/testbin/bin
 
-CRD_SPEC_VERSION ?= v1
-CRD_ROOT_DIR ?= config/crd/v1alpha1
 CRD_FILE ?= clustercode-crd.yaml
+CRD_ROOT_DIR ?= config/crd/v1alpha1
+CRD_SPEC_VERSION ?= v1
 
-OPERATOR_NAMESPACE ?= clustercode-system
-
-TESTBIN_DIR ?= ./testbin/bin
 # See https://storage.googleapis.com/kubebuilder-tools/ for list of supported K8s versions
 INTEGRATIONTEST_K8S_VERSION ?= 1.20.2
+
 KIND_VERSION ?= 0.9.0
-KIND_KUBECONFIG ?= testbin/kind-kubeconfig
 KIND_NODE_VERSION ?= v1.20.0
+KIND ?= $(TESTBIN_DIR)/kind
+
+ENABLE_LEADER_ELECTION ?= false
+
+KIND_KUBECONFIG ?= $(TESTBIN_DIR)/kind-kubeconfig-$(KIND_NODE_VERSION)
 KIND_CLUSTER ?= clustercode-$(KIND_NODE_VERSION)
 KIND_KUBECTL_ARGS ?= --validate=true
 
-KUSTOMIZE ?= go run sigs.k8s.io/kustomize/kustomize/v3
-KUSTOMIZE_BUILD_CRD ?= $(KUSTOMIZE) build $(CRD_ROOT_DIR)
+E2E_TAG ?= e2e_$(shell sha1sum $(BIN_FILENAME) | cut -b-8)
+E2E_REPO ?= local.dev/clustercode/e2e
+E2E_IMG = $(E2E_REPO):$(E2E_TAG)
+OPERATOR_NAMESPACE ?= clustercode-system
 
+KUSTOMIZE ?= go run sigs.k8s.io/kustomize/kustomize/v3
 
 # Image URL to use all building/pushing image targets
 DOCKER_IMG ?= docker.io/ccremer/clustercode:$(IMG_TAG)
 QUAY_IMG ?= quay.io/ccremer/clustercode:$(IMG_TAG)
-E2E_IMG ?= localhost:$(KIND_REGISTRY_PORT)/clustercode/operator:e2e
 FFMPEG_IMG ?= docker.io/jrottenberg/ffmpeg:4.1-alpine
 
-# Run tests (see https://sdk.operatorframework.io/docs/building-operators/golang/references/envtest-setup)
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
+testbin_created = $(TESTBIN_DIR)/.created
 
 # Trigger Documentation workflow in another repository
 #

--- a/data/Makefile
+++ b/data/Makefile
@@ -1,0 +1,40 @@
+# Set Shell to bash, otherwise some targets fail with dash/zsh etc.
+SHELL := /bin/bash
+
+# Disable built-in rules
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-builtin-variables
+.SUFFIXES:
+.SECONDARY:
+
+include ../Makefile.vars.mk
+
+media_source_dir = source
+media_intermediate_dir = intermediate
+media_target_dir = target
+
+media_filename = $(media_source_dir)/blank_video.mp4
+
+.PHONY: blank-media
+blank-media: $(media_filename) $(media_intermediate_dir) $(media_target_dir) ## Creates a blank video file
+
+.PHONY: clean
+clean: ## Cleans the intermediate and target dirs
+	rm -rf $(media_source_dir) $(media_intermediate_dir) $(media_target_dir) || true
+
+###
+### Assets
+###
+
+$(media_source_dir):
+	@mkdir -p $@
+
+$(media_intermediate_dir):
+	@mkdir -p $@
+
+$(media_target_dir):
+	@mkdir -p $@
+
+$(media_filename): $(media_source_dir)
+	docker run --rm -u $(shell id -u) -v $${PWD}/$(media_source_dir):/data $(FFMPEG_IMG) -y -hide_banner -t 30 -f lavfi -i color=c=black:s=320x240 -c:v libx264 -tune stillimage -pix_fmt yuv420p /data/blank_video.mp4
+	@docker run --rm -v $${PWD}/$(media_source_dir):/data --entrypoint /bin/sh $(FFMPEG_IMG) -c "chmod -R 664 /data/*"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,19 +1,30 @@
 # Set Shell to bash, otherwise some targets fail with dash/zsh etc.
 SHELL := /bin/bash
 
-DOCS_DIR ?= .
+# Disable built-in rules
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-builtin-variables
+.SUFFIXES:
+.SECONDARY:
 
 ANTORA_PLAYBOOK_PATH ?= local-antora-playbook.yml
-ANTORA_OUTPUT_DIR ?= $(shell cd $(DOCS_DIR) && grep dir $(ANTORA_PLAYBOOK_PATH) | cut -d " " -f 4)
+ANTORA_OUTPUT_DIR ?= $(shell grep "dir" $(ANTORA_PLAYBOOK_PATH) | cut -d " " -f 4)
 
-docs-build: $(DOCS_DIR)/node_modules
-	cd $(DOCS_DIR) && npm run build
+.PHONY: build
+build: node_modules ## Build Antora documentation
+	npm run build
 
-$(DOCS_DIR)/node_modules:
-	cd $(DOCS_DIR) && npm install
+node_modules:
+	npm install
 
-docs-clean:
-	cd $(DOCS_DIR) && rm -r $(ANTORA_OUTPUT_DIR) node_modules || true
+.PHONY: clean
+clean: ## Clean documentation artifacts
+	rm -r $(ANTORA_OUTPUT_DIR) node_modules || true
 
-docs-preview: docs-build ## Preview Antora build in local web server
-	cd $(DOCS_DIR) && npm run preview
+.PHONY: preview
+preview: build ## Preview Antora build in local web server and browser
+	npm run preview
+
+.PHONY: help
+help: ## Show this help
+	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/docs/supplemental-ui/partials/footer-content.hbs
+++ b/docs/supplemental-ui/partials/footer-content.hbs
@@ -1,0 +1,4 @@
+<!--
+This page was built using the Antora default UI.
+The source code for this UI is licensed under the terms of the MPL-2.0 license.
+-->

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,74 +1,57 @@
-
 # Set Shell to bash, otherwise some targets fail with dash/zsh etc.
 SHELL := /bin/bash
 
-E2E_DIR ?= .
+# Disable built-in rules
+MAKEFLAGS += --no-builtin-rules
+MAKEFLAGS += --no-builtin-variables
+.SUFFIXES:
+.SECONDARY:
 
-#### Usable for the developer
-setup_e2e_test: $(setup_e2e_test) ## Run the e2e setup
+PROJECT_ROOT_DIR = ..
+include ../Makefile.vars.mk
+include kind.mk
 
-e2e_test: export E2E_IMAGE = $(E2E_IMG)
-e2e_test: install_bats $(setup_e2e_test) $(KIND_KUBECONFIG)  ## Runs the e2e test suite (this is the one you want)
-e2e_test: docker-build kind_load_image run_bats
+ifeq ($(shell uname -s),Linux)
+	xargs := xargs --no-run-if-empty
+else
+	xargs := xargs
+endif
 
-clean_e2e_setup: export KUBECONFIG = $(KIND_KUBECONFIG)
-clean_e2e_setup: ## Clean the e2e setup (e.g. to rerun the setup_e2e_test)
-	kubectl delete ns $(OPERATOR_NAMESPACE) --ignore-not-found --force --grace-period=0 || true
-	@$(KUSTOMIZE_BUILD_CRD) | kubectl delete -f - || true
-	@rm $(setup_e2e_test) $(E2E_DIR)/debug $(E2E_DIR)/node_modules || true
-
-run_kind: export KUBECONFIG = $(KIND_KUBECONFIG)
-run_kind: $(setup_e2e_test) ## Runs the operator in kind
-	go run ./main.go -v operate --operator.clustercode-image=$(E2E_IMG)
-####
-
-
-
-#### Everything BATS related
-.PHONY: run_bats install_bats
-
+bats := node_modules/.bin/bats
 bats_args ?=
 
-run_bats: export KUBECONFIG = ../$(KIND_KUBECONFIG)
-run_bats: install_bats ## Actually runs the bats test
-	@mkdir -p $(E2E_DIR)/debug || true
-	@cd $(E2E_DIR) && node_modules/.bin/bats . $(bats_args)
+.DEFAULT_GOAL := help
 
-install_bats: $(E2E_DIR)/node_modules/.bin/bats ## Installs the bats util via NPM
+.PHONY: test
+test: export KUBECONFIG = $(KIND_KUBECONFIG)
+test: export E2E_IMAGE = $(E2E_IMG)
+test: setup kind-e2e-image ## Run the E2E tests
+	@mkdir -p debug
+	@$(bats) . $(bats_args)
 
-$(E2E_DIR)/node_modules/.bin/bats: $(E2E_DIR)/node_modules
+kind-e2e-image: kind-setup ## Load the e2e container image onto e2e cluster
+	@$(KIND) load docker-image --name $(KIND_CLUSTER) $(E2E_IMG)
 
-$(E2E_DIR)/node_modules:
-	@cd $(E2E_DIR) && npm install
-####
+.PHONY: setup
+setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+setup: $(bats) kind-setup ## Run the e2e setup
 
+.PHONY: clean-setup
+clean-setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+clean-setup: kind-clean ## Clean the e2e setup (e.g. to rerun the setup)
 
+.PHONY: clean
+clean: clean-setup ## Remove all e2e-related resources (incl. all e2e Docker images)
+	docker images --filter "reference=$(E2E_REPO)" --format "{{.Repository }}:{{ .Tag }}" | $(xargs) docker rmi || true
+	rm -r debug node_modules || true
 
-#### Everything KIND related
-kind_bin ?= $(TESTBIN_DIR)/kind
-setup_e2e_test := testbin/.setup_e2e_test
+.PHONY: help
+help: ## Show this help
+	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-kind_load_image:
-	@$(kind_bin) load docker-image --name $(KIND_CLUSTER) $(E2E_IMG)
-	@docker rmi $(E2E_IMG)
+###
+### Artifacts
+###
 
-$(kind_bin): export KUBECONFIG = $(KIND_KUBECONFIG)
-$(kind_bin): $(TESTBIN_DIR)
-	curl -fLo $(kind_bin) "https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-$$(uname)-amd64"
-	@chmod +x $(kind_bin)
-	$(kind_bin) create cluster --name $(KIND_CLUSTER) --image kindest/node:$(KIND_NODE_VERSION) --config=e2e/kind-config.yaml
-	@kubectl version
-	@kubectl cluster-info
-
-$(KIND_KUBECONFIG): $(kind_bin)
-
-$(setup_e2e_test): export KUBECONFIG = $(KIND_KUBECONFIG)
-$(setup_e2e_test): $(kind_bin)
-	@kubectl config use-context kind-$(KIND_CLUSTER)
-	@$(KUSTOMIZE_BUILD_CRD) | kubectl apply $(KIND_KUBECTL_ARGS) -f -
-	@touch $(setup_e2e_test)
-
-clean-e2e:
-	$(kind_bin) delete cluster --name $(KIND_CLUSTER) || true
-	docker images --filter "reference=$(E2E_REPO)" --format "{{.Repository }}:{{ .Tag }}" | xargs --no-run-if-empty docker rmi || true
-####
+$(bats):
+	@npm install

--- a/e2e/kind.mk
+++ b/e2e/kind.mk
@@ -1,0 +1,42 @@
+kind_marker := $(TESTBIN_DIR)/.kind-setup_complete
+
+curl_args ?= --location --fail --silent --show-error
+
+.DEFAULT_TARGET: kind-setup
+
+.PHONY: kind-setup
+kind-setup: export KUBECONFIG = $(KIND_KUBECONFIG)
+kind-setup: $(kind_marker) ## Creates the kind cluster
+
+.PHONY: kind-clean
+kind-clean: export KUBECONFIG = $(KIND_KUBECONFIG)
+kind-clean: ## Remove the kind Cluster
+	@$(KIND) delete cluster --name $(KIND_CLUSTER) || true
+	@rm $(KIND) $(kind_marker) $(KIND_KUBECONFIG) || true
+
+###
+### Artifacts
+###
+
+$(KIND): export KUBECONFIG = $(KIND_KUBECONFIG)
+$(KIND): $(testbin_created)
+	curl $(curl_args) --output "$(KIND)" "https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-$$(uname)-amd64"
+	@chmod +x $(KIND)
+
+$(KIND_KUBECONFIG): export KUBECONFIG = $(KIND_KUBECONFIG)
+$(KIND_KUBECONFIG): $(KIND)
+	$(KIND) create cluster --name $(KIND_CLUSTER) --image kindest/node:$(KIND_NODE_VERSION) --config=kind-config.yaml
+	@kubectl version
+	@kubectl cluster-info
+
+$(kind_marker): export KUBECONFIG = $(KIND_KUBECONFIG)
+$(kind_marker): $(KIND_KUBECONFIG)
+	@kubectl config use-context kind-$(KIND_CLUSTER)
+	@touch $(kind_marker)
+
+$(testbin_created):
+	mkdir -p $(TESTBIN_DIR)
+	# a marker file must be created, because the date of the
+	# directory may update when content in it is created/updated,
+	# which would cause a rebuild / re-initialization of dependants
+	@touch $(testbin_created)

--- a/e2e/test1.bats
+++ b/e2e/test1.bats
@@ -13,12 +13,13 @@ DEBUG_DETIK="true"
 }
 
 @test "verify the deployment" {
-  go run sigs.k8s.io/kustomize/kustomize/v3 build test1 > debug/test1.yaml
+  go run sigs.k8s.io/kustomize/kustomize/v3 build test1 -o debug/test1.yaml
   sed -i -e "s|\$E2E_IMAGE|${E2E_IMAGE}|" debug/test1.yaml
   debug "$output"
   run kubectl apply -f debug/test1.yaml
   debug "$output"
 
-  try "at most 20 times every 2s to find 1 pod named 'clustercode-operator' with 'status' being 'running'"
+  try "at most 10 times every 2s to find 1 pod named 'clustercode-operator' with '.spec.containers[*].image' being '${E2E_IMAGE}'"
+  try "at most 10 times every 2s to find 1 pod named 'clustercode-operator' with 'status' being 'running'"
 
 }


### PR DESCRIPTION
## Summary

* Cleans up root Makefile by moving most e2e and KIND targets to e2e dir, leaving only a few make targets as the interface.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->
- [x] Update tests.
