### PR TITLE
Deploy additional Service Accounts for webui

### DIFF
--- a/charts/clustercode/Chart.yaml
+++ b/charts/clustercode/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clustercode/README.gotmpl.md
+++ b/charts/clustercode/README.gotmpl.md
@@ -31,6 +31,25 @@ helm install {{ template "chart.name" . }} clustercode/{{ template "chart.name" 
 ```
 (Note that the name and namespace must match the certificate you created in the step before.)
 
+### WebUI
+
+By default, the WebUI is also installed.
+To log into the frontend, you must provide Kubernetes tokens in the login form as the frontend talks directly to the Kubernetes API.
+
+To get a token, you can create Service Accounts with the `webui.users` parameter.
+Once deployed, get the token by the following command:
+
+```bash
+kubectl -n clustercode-system get secret clustercode-webadmin -o jsonpath='{.data.token}' | base64 -d
+```
+
+Alternatively, set `.skipSecret` in `webui.users[*]` to skip creating a Secret for the Service Account.
+To get a time-limited token without permanent Secret, you can generate one with kubectl:
+
+```bash
+kubectl -n clustercode-system create token clustercode-webadmin
+```
+
 ## Handling CRDs
 
 * Always upgrade the CRDs before upgrading the Helm release.

--- a/charts/clustercode/README.md
+++ b/charts/clustercode/README.md
@@ -1,6 +1,6 @@
 # clustercode
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Movie and Series conversion Operator with Ffmpeg
 
@@ -15,7 +15,7 @@ Edit the README.gotmpl.md template instead.
 
 Install the CRDs:
 ```bash
-kubectl apply -f https://github.com/ccremer/clustercode/releases/download/clustercode-0.3.0/crds.yaml
+kubectl apply -f https://github.com/ccremer/clustercode/releases/download/clustercode-0.4.0/crds.yaml
 ```
 
 To prepare the webhook server, you need `yq`, `openssl`, `base64` tools and run this:
@@ -37,6 +37,25 @@ helm install clustercode clustercode/clustercode \
   --values webhook-values.yaml
 ```
 (Note that the name and namespace must match the certificate you created in the step before.)
+
+### WebUI
+
+By default, the WebUI is also installed.
+To log into the frontend, you must provide Kubernetes tokens in the login form as the frontend talks directly to the Kubernetes API.
+
+To get a token, you can create Service Accounts with the `webui.users` parameter.
+Once deployed, get the token by the following command:
+
+```bash
+kubectl -n clustercode-system get secret clustercode-webadmin -o jsonpath='{.data.token}' | base64 -d
+```
+
+Alternatively, set `.skipSecret` in `webui.users[*]` to skip creating a Secret for the Service Account.
+To get a time-limited token without permanent Secret, you can generate one with kubectl:
+
+```bash
+kubectl -n clustercode-system create token clustercode-webadmin
+```
 
 ## Handling CRDs
 
@@ -109,6 +128,10 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | webui.resources.requests.memory | string | `"32Mi"` |  |
 | webui.service.annotations | object | `{}` | Annotations to add to the webhook service. |
 | webui.service.port | int | `80` | Service port |
+| webui.users | list | see below | List of Service Accounts that can access the web-ui. |
+| webui.users[0].name | string | `"clustercode-webadmin"` | name of the Service Account |
+| webui.users[0].namespace | string | `""` | namespace of the Service Account, defaults to release namespace |
+| webui.users[0].skipSecret | bool | `false` | If true, no Secret will be created for the Service Account |
 
 ## Source Code
 

--- a/charts/clustercode/templates/webui/user-sa.yaml
+++ b/charts/clustercode/templates/webui/user-sa.yaml
@@ -1,0 +1,14 @@
+{{- range .Values.webui.users -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "clustercode.labels" $ | nindent 4 }}
+{{- if not .skipSecret }}
+secrets:
+  - name: {{ .name }}
+{{ end }}
+{{- end }}

--- a/charts/clustercode/templates/webui/user-secret.yaml
+++ b/charts/clustercode/templates/webui/user-secret.yaml
@@ -1,0 +1,15 @@
+{{- range .Values.webui.users -}}
+{{- if not .skipSecret }}
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "clustercode.labels" $ | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ .name }}
+{{- end }}
+{{- end }}

--- a/charts/clustercode/values.yaml
+++ b/charts/clustercode/values.yaml
@@ -131,6 +131,16 @@ webui:
     #    hosts:
     #      - chart-example.local
 
+  # -- List of Service Accounts that can access the web-ui.
+  # @default -- see below
+  users:
+    - # -- name of the Service Account
+      name: clustercode-webadmin
+      # -- namespace of the Service Account, defaults to release namespace
+      namespace: ""
+      # -- If true, no Secret will be created for the Service Account
+      skipSecret: false
+
 # -- The operator's pod node selector
 nodeSelector: {}
 


### PR DESCRIPTION
## Summary

* Adds `webui.users` parameter to deploy additional service accounts for the webui part
* See also #190 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:clustercode`
- x ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.
