### PR TITLE
Use Cypress GH action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,4 +51,7 @@ jobs:
           cache-dependency-path: ui/package-lock.json
 
       - name: Run tests
-        run: make test-ui
+        uses: cypress-io/github-action@v4
+        with:
+          component: true
+          working-directory: ui

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -5,8 +5,7 @@ import 'dotenv/config'
 // https://vitejs.dev/config/
 export default defineConfig(({mode}) => {
   if (mode !== "production" && !process.env.VITE_KUBERNETES_API_URL) {
-    console.log('environment variable VITE_KUBERNETES_API_URL is not defined')
-    process.exit(1)
+    console.log('⚠️  WARNING ⚠️ :environment variable VITE_KUBERNETES_API_URL is not defined. API may not be working!')
   }
   return {
     plugins: [svelte()],


### PR DESCRIPTION
## Summary

* Switches to a dedicated Cypress action for better support of future test analysis
* Fixes the endless run of the previous jobs if the Kubernetes Env var wasn't set

## Checklist


- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
