### PR TITLE
Update defaults for K8s API URL auto-discovery

### DIFF
--- a/charts/clustercode/Chart.yaml
+++ b/charts/clustercode/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clustercode/README.md
+++ b/charts/clustercode/README.md
@@ -1,6 +1,6 @@
 # clustercode
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Movie and Series conversion Operator with Ffmpeg
 
@@ -15,7 +15,7 @@ Edit the README.gotmpl.md template instead.
 
 Install the CRDs:
 ```bash
-kubectl apply -f https://github.com/ccremer/clustercode/releases/download/clustercode-0.3.0/crds.yaml
+kubectl apply -f https://github.com/ccremer/clustercode/releases/download/clustercode-0.3.1/crds.yaml
 ```
 
 To prepare the webhook server, you need `yq`, `openssl`, `base64` tools and run this:
@@ -112,8 +112,8 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | webui.api.externalName | object | `{"service":"kubernetes.default.svc.cluster.local"}` | The internal service name where the API service is served. |
 | webui.api.externalName.service | string | `"kubernetes.default.svc.cluster.local"` | The Kubernetes service which the Ingress exposes additionally. This is likely only working with TLS. |
 | webui.api.mode | string | `"proxy"` | The mode under which the Kubernetes API is served. Supported values: ["externalName", "proxy"] In case of CORS issues, you may use the integrated proxy. |
-| webui.api.proxy.skipTlsVerify | bool | `false` | Whether TLS certificate verifications should be skipped. |
-| webui.api.proxy.url | string | `"https://kubernetes.default.svc.cluster.local:443"` | The Kubernetes full base URL for the API. Ideally this is an internal URL. |
+| webui.api.proxy.skipTlsVerify | bool | `true` | Whether TLS certificate verifications should be skipped. |
+| webui.api.proxy.url | string | `"auto"` | The Kubernetes full base URL for the API. Ideally this is an internal URL. If set to `auto`, the URL is detected based on the Service Account token. |
 | webui.enabled | bool | `true` | Whether the WebUI deployment is enabled |
 | webui.ingress.annotations | object | `{}` | Annotations to add to the Ingress |
 | webui.ingress.className | string | `""` |  |

--- a/charts/clustercode/values.yaml
+++ b/charts/clustercode/values.yaml
@@ -102,9 +102,10 @@ webui:
     proxy:
       # -- The Kubernetes full base URL for the API.
       # Ideally this is an internal URL.
-      url: https://kubernetes.default.svc.cluster.local:443
+      # If set to `auto`, the URL is detected based on the Service Account token.
+      url: auto
       # -- Whether TLS certificate verifications should be skipped.
-      skipTlsVerify: false
+      skipTlsVerify: true
 
   service:
     # -- Annotations to add to the webhook service.

--- a/test/values.yaml
+++ b/test/values.yaml
@@ -2,8 +2,3 @@ clustercode:
   env:
     - name: CC_LOG_LEVEL
       value: "2"
-
-webui:
-  api:
-    proxy:
-      skipTlsVerify: true


### PR DESCRIPTION
## Summary

* Updates chart defaults to reflect #195 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] PR contains the label `area:chart`
- [x] PR contains the chart label, e.g. `chart:clustercode`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Chart Version bumped if immediate release after merging is planned
- [x] I have run `make chart-docs`
- [x] Link this PR to related code release or other issues.

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
