### PR TITLE
Replace codeclimate with golangci-lint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,0 @@
-version: "2"
-exclude_patterns:
-- '**/node_modules/'
-- 'e2e/lib/'
-- '**/zz_generated.deepcopy.go'
-- 'docs/*.js'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Run linters
         run: make lint-go git-diff
 
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          skip-pkg-cache: true
+          args: --timeout 5m --out-${NO_FUTURE}format colored-line-number
+
   ui:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,14 +31,6 @@ jobs:
       - name: Run tests
         run: make test-integration
 
-      - name: Upload code coverage report to Code Climate
-        uses: paambaati/codeclimate-action@v3.1.1
-        env:
-          CC_TEST_REPORTER_ID: 273b145c3b441d2abc054951c66b99a6d55f9eb4a25ddacd0731e14fcc921dc2
-        with:
-          coverageLocations: cover.out:gocov
-          prefix: github.com/${{ github.repository }}
-
   cypress:
     runs-on: ubuntu-latest
     steps:

--- a/README.adoc
+++ b/README.adoc
@@ -13,8 +13,6 @@ endif::[]
 image:https://img.shields.io/github/workflow/status/ccremer/clustercode/Test[Test,link=https://github.com/ccremer/clustercode/actions?query=workflow%3ATest]
 image:https://img.shields.io/github/go-mod/go-version/ccremer/clustercode[Go version]
 image:https://img.shields.io/github/v/release/ccremer/clustercode?include_prereleases[Version,link=https://github.com/ccremer/clustercode/releases]
-image:https://img.shields.io/codeclimate/maintainability/ccremer/clustercode[Maintainability,link=https://codeclimate.com/github/ccremer/clustercode]
-image:https://img.shields.io/codeclimate/coverage/ccremer/clustercode[Code Coverage,link=https://codeclimate.com/github/ccremer/clustercode]
 
 Automatically convert your movies and TV shows from one file format to another using ffmpeg in a cluster.
 It's like an Ffmpeg operator!

--- a/pkg/operator/blueprintcontroller/controller.go
+++ b/pkg/operator/blueprintcontroller/controller.go
@@ -35,7 +35,6 @@ type BlueprintProvisioner struct {
 type BlueprintContext struct {
 	context.Context
 	blueprint *v1alpha1.Blueprint
-	log       logr.Logger
 }
 
 func (r *BlueprintProvisioner) NewObject() *v1alpha1.Blueprint {

--- a/pkg/operator/jobcontroller/controller.go
+++ b/pkg/operator/jobcontroller/controller.go
@@ -33,7 +33,6 @@ type (
 		job        *batchv1.Job
 		jobType    internaltypes.ClusterCodeJobType
 		task       *v1alpha1.Task
-		log        logr.Logger
 		sliceIndex int
 	}
 )

--- a/pkg/operator/taskcontroller/controller.go
+++ b/pkg/operator/taskcontroller/controller.go
@@ -29,7 +29,6 @@ type (
 		context.Context
 		resolver       pipeline.DependencyResolver[*TaskContext]
 		task           *v1alpha1.Task
-		blueprint      *v1alpha1.Blueprint
 		job            *batchv1.Job
 		nextSliceIndex int
 	}

--- a/pkg/scancmd/run.go
+++ b/pkg/scancmd/run.go
@@ -34,7 +34,6 @@ type commandContext struct {
 
 	kube            client.Client
 	blueprint       *v1alpha1.Blueprint
-	segmentFiles    []string
 	currentTasks    []v1alpha1.Task
 	selectedRelPath string
 }

--- a/pkg/webhook/blueprintwebhook/defaulter_test.go
+++ b/pkg/webhook/blueprintwebhook/defaulter_test.go
@@ -1,6 +1,7 @@
 package blueprintwebhook
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ccremer/clustercode/pkg/api/v1alpha1"
@@ -31,7 +32,7 @@ func TestDefaulter_Default(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			d := &Defaulter{Log: logr.Discard()}
 			bp := &v1alpha1.Blueprint{Spec: tt.givenSpec}
-			err := d.Default(nil, bp)
+			err := d.Default(context.TODO(), bp)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedSpec, bp.Spec)
 		})

--- a/ui/embed.init.go
+++ b/ui/embed.init.go
@@ -10,8 +10,5 @@ var PublicFs embed.FS
 // The UI assets are embedded when built with `ui` tag.
 func IsEmbedded() bool {
 	_, err := PublicFs.ReadFile("dist/index.html")
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }


### PR DESCRIPTION
## Summary

* Replace codeclimate with golangci-lint, since codeclimate seems to have abandoned Go support.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `kind:bug`, `kind:enhancement`, `kind:documentation`, `kind:change`, `kind:breaking`, `kind:dependency`
      as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] I have not made _any_ changes in the `charts/` directory.
